### PR TITLE
Brevity: use reciperadar.db in preference to sqlalchemy module imports

### DIFF
--- a/reciperadar/models/events/base.py
+++ b/reciperadar/models/events/base.py
@@ -1,13 +1,8 @@
 from abc import ABC
 from datetime import datetime
-from sqlalchemy import (
-    Boolean,
-    Column,
-    DateTime,
-    String,
-)
 from uuid import uuid4
 
+from reciperadar import db
 from reciperadar.models.base import Storable
 
 
@@ -15,6 +10,6 @@ class BaseEvent(Storable):
     __abstract__ = True
     __metaclass__ = ABC
 
-    event_id = Column(String, default=uuid4, primary_key=True)
-    logged_at = Column(DateTime, default=datetime.utcnow, nullable=False)
-    suspected_bot = Column(Boolean, default=False)
+    event_id = db.Column(db.String, default=uuid4, primary_key=True)
+    logged_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    suspected_bot = db.Column(db.Boolean, default=False)

--- a/reciperadar/models/events/redirect.py
+++ b/reciperadar/models/events/redirect.py
@@ -1,13 +1,10 @@
-from sqlalchemy import (
-    Column,
-    String,
-)
+from reciperadar import db
 from reciperadar.models.events.base import BaseEvent
 
 
 class RedirectEvent(BaseEvent):
     __tablename__ = 'redirects'
 
-    recipe_id = Column(String)
-    domain = Column(String)
-    src = Column(String)
+    recipe_id = db.Column(db.String)
+    domain = db.Column(db.String)
+    src = db.Column(db.String)

--- a/reciperadar/models/events/search.py
+++ b/reciperadar/models/events/search.py
@@ -1,21 +1,17 @@
-from sqlalchemy import (
-    Column,
-    Integer,
-    String,
-)
 from sqlalchemy.dialects import postgresql
 
+from reciperadar import db
 from reciperadar.models.events.base import BaseEvent
 
 
 class SearchEvent(BaseEvent):
     __tablename__ = 'searches'
 
-    include = Column(postgresql.ARRAY(String))
-    exclude = Column(postgresql.ARRAY(String))
-    equipment = Column(postgresql.ARRAY(String))
-    offset = Column(Integer)
-    limit = Column(Integer)
-    sort = Column(String)
-    results_ids = Column(postgresql.ARRAY(String))
-    results_total = Column(Integer)
+    include = db.Column(postgresql.ARRAY(db.String))
+    exclude = db.Column(postgresql.ARRAY(db.String))
+    equipment = db.Column(postgresql.ARRAY(db.String))
+    offset = db.Column(db.Integer)
+    limit = db.Column(db.Integer)
+    sort = db.Column(db.String)
+    results_ids = db.Column(postgresql.ARRAY(db.String))
+    results_total = db.Column(db.Integer)

--- a/reciperadar/models/recipes/appliance.py
+++ b/reciperadar/models/recipes/appliance.py
@@ -1,20 +1,15 @@
-from sqlalchemy import (
-    Column,
-    ForeignKey,
-    String,
-)
-
+from reciperadar import db
 from reciperadar.models.base import Storable
 
 
 class DirectionAppliance(Storable):
     __tablename__ = 'direction_appliances'
 
-    fk = ForeignKey('recipe_directions.id', ondelete='cascade')
-    direction_id = Column(String, fk, index=True)
+    fk = db.ForeignKey('recipe_directions.id', ondelete='cascade')
+    direction_id = db.Column(db.String, fk, index=True)
 
-    id = Column(String, primary_key=True)
-    appliance = Column(String)
+    id = db.Column(db.String, primary_key=True)
+    appliance = db.Column(db.String)
 
     @staticmethod
     def from_doc(doc):

--- a/reciperadar/models/recipes/direction.py
+++ b/reciperadar/models/recipes/direction.py
@@ -1,11 +1,4 @@
-from sqlalchemy import (
-    Column,
-    ForeignKey,
-    Integer,
-    String,
-)
-from sqlalchemy.orm import relationship
-
+from reciperadar import db
 from reciperadar.models.base import Storable
 from reciperadar.models.recipes.appliance import DirectionAppliance
 from reciperadar.models.recipes.utensil import DirectionUtensil
@@ -15,24 +8,24 @@ from reciperadar.models.recipes.vessel import DirectionVessel
 class RecipeDirection(Storable):
     __tablename__ = 'recipe_directions'
 
-    fk = ForeignKey('recipes.id', ondelete='cascade')
-    recipe_id = Column(String, fk, index=True)
+    fk = db.ForeignKey('recipes.id', ondelete='cascade')
+    recipe_id = db.Column(db.String, fk, index=True)
 
-    id = Column(String, primary_key=True)
-    index = Column(Integer)
-    description = Column(String)
-    markup = Column(String)
-    appliances = relationship(
+    id = db.Column(db.String, primary_key=True)
+    index = db.Column(db.Integer)
+    description = db.Column(db.String)
+    markup = db.Column(db.String)
+    appliances = db.relationship(
         'DirectionAppliance',
         backref='recipe_directions',
         passive_deletes='all'
     )
-    utensils = relationship(
+    utensils = db.relationship(
         'DirectionUtensil',
         backref='recipe_directions',
         passive_deletes='all'
     )
-    vessels = relationship(
+    vessels = db.relationship(
         'DirectionVessel',
         backref='recipe_directions',
         passive_deletes='all'

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -1,12 +1,4 @@
-from sqlalchemy import (
-    Column,
-    Float,
-    ForeignKey,
-    Integer,
-    String,
-)
-from sqlalchemy.orm import relationship
-
+from reciperadar import db
 from reciperadar.models.base import Searchable, Storable
 from reciperadar.models.recipes.product import IngredientProduct
 
@@ -14,25 +6,25 @@ from reciperadar.models.recipes.product import IngredientProduct
 class RecipeIngredient(Storable, Searchable):
     __tablename__ = 'recipe_ingredients'
 
-    fk = ForeignKey('recipes.id', ondelete='cascade')
-    recipe_id = Column(String, fk, index=True)
+    fk = db.ForeignKey('recipes.id', ondelete='cascade')
+    recipe_id = db.Column(db.String, fk, index=True)
 
-    id = Column(String, primary_key=True)
-    index = Column(Integer)
-    description = Column(String)
-    markup = Column(String)
-    product = relationship(
+    id = db.Column(db.String, primary_key=True)
+    index = db.Column(db.Integer)
+    description = db.Column(db.String)
+    markup = db.Column(db.String)
+    product = db.relationship(
         'IngredientProduct',
         backref='recipe_ingredient',
         uselist=False,
         passive_deletes='all'
     )
 
-    quantity = Column(Float)
-    quantity_parser = Column(String)
-    units = Column(String)
-    units_parser = Column(String)
-    verb = Column(String)
+    quantity = db.Column(db.Float)
+    quantity_parser = db.Column(db.String)
+    units = db.Column(db.String)
+    units_parser = db.Column(db.String)
+    verb = db.Column(db.String)
 
     @staticmethod
     def from_doc(doc):

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -1,29 +1,24 @@
-from sqlalchemy import (
-    Boolean,
-    Column,
-    ForeignKey,
-    String,
-)
 from sqlalchemy.dialects import postgresql
 
+from reciperadar import db
 from reciperadar.models.base import Storable
 
 
 class IngredientProduct(Storable):
     __tablename__ = 'ingredient_products'
 
-    fk = ForeignKey('recipe_ingredients.id', ondelete='cascade')
-    ingredient_id = Column(String, fk, index=True)
+    fk = db.ForeignKey('recipe_ingredients.id', ondelete='cascade')
+    ingredient_id = db.Column(db.String, fk, index=True)
 
-    id = Column(String, primary_key=True)
-    product_id = Column(String)
-    product = Column(String)
-    product_parser = Column(String)
-    is_plural = Column(Boolean)
-    singular = Column(String)
-    plural = Column(String)
-    category = Column(String)
-    contents = Column(postgresql.ARRAY(String))
+    id = db.Column(db.String, primary_key=True)
+    product_id = db.Column(db.String)
+    product = db.Column(db.String)
+    product_parser = db.Column(db.String)
+    is_plural = db.Column(db.Boolean)
+    singular = db.Column(db.String)
+    plural = db.Column(db.String)
+    category = db.Column(db.String)
+    contents = db.Column(postgresql.ARRAY(db.String))
 
     STATE_AVAILABLE = 'available'
     STATE_REQUIRED = 'required'

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -1,13 +1,6 @@
 from pymmh3 import hash_bytes
-from sqlalchemy import (
-    Column,
-    DateTime,
-    Float,
-    Integer,
-    String,
-)
-from sqlalchemy.orm import relationship
 
+from reciperadar import db
 from reciperadar.models.base import Searchable, Storable
 from reciperadar.models.recipes.direction import RecipeDirection
 from reciperadar.models.recipes.ingredient import RecipeIngredient
@@ -16,27 +9,27 @@ from reciperadar.models.recipes.ingredient import RecipeIngredient
 class Recipe(Storable, Searchable):
     __tablename__ = 'recipes'
 
-    id = Column(String, primary_key=True)
-    title = Column(String)
-    src = Column(String)
-    dst = Column(String)
-    domain = Column(String)
-    image_src = Column(String)
-    time = Column(Integer)
-    servings = Column(Integer)
-    rating = Column(Float)
-    ingredients = relationship(
+    id = db.Column(db.String, primary_key=True)
+    title = db.Column(db.String)
+    src = db.Column(db.String)
+    dst = db.Column(db.String)
+    domain = db.Column(db.String)
+    image_src = db.Column(db.String)
+    time = db.Column(db.Integer)
+    servings = db.Column(db.Integer)
+    rating = db.Column(db.Float)
+    ingredients = db.relationship(
         'RecipeIngredient',
         backref='recipe',
         passive_deletes='all'
     )
-    directions = relationship(
+    directions = db.relationship(
         'RecipeDirection',
         backref='recipe',
         passive_deletes='all'
     )
 
-    indexed_at = Column(DateTime)
+    indexed_at = db.Column(db.DateTime)
 
     @property
     def noun(self):

--- a/reciperadar/models/recipes/utensil.py
+++ b/reciperadar/models/recipes/utensil.py
@@ -1,20 +1,15 @@
-from sqlalchemy import (
-    Column,
-    ForeignKey,
-    String,
-)
-
+from reciperadar import db
 from reciperadar.models.base import Storable
 
 
 class DirectionUtensil(Storable):
     __tablename__ = 'direction_utensils'
 
-    fk = ForeignKey('recipe_directions.id', ondelete='cascade')
-    direction_id = Column(String, fk, index=True)
+    fk = db.ForeignKey('recipe_directions.id', ondelete='cascade')
+    direction_id = db.Column(db.String, fk, index=True)
 
-    id = Column(String, primary_key=True)
-    utensil = Column(String)
+    id = db.Column(db.String, primary_key=True)
+    utensil = db.Column(db.String)
 
     @staticmethod
     def from_doc(doc):

--- a/reciperadar/models/recipes/vessel.py
+++ b/reciperadar/models/recipes/vessel.py
@@ -1,20 +1,15 @@
-from sqlalchemy import (
-    Column,
-    ForeignKey,
-    String,
-)
-
+from reciperadar import db
 from reciperadar.models.base import Storable
 
 
 class DirectionVessel(Storable):
     __tablename__ = 'direction_vessels'
 
-    fk = ForeignKey('recipe_directions.id', ondelete='cascade')
-    direction_id = Column(String, fk, index=True)
+    fk = db.ForeignKey('recipe_directions.id', ondelete='cascade')
+    direction_id = db.Column(db.String, fk, index=True)
 
-    id = Column(String, primary_key=True)
-    vessel = Column(String)
+    id = db.Column(db.String, primary_key=True)
+    vessel = db.Column(db.String)
 
     @staticmethod
     def from_doc(doc):

--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -1,9 +1,9 @@
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
-from sqlalchemy import Column, DateTime, Integer, String
 import requests
 from tldextract import TLDExtract
 
+from reciperadar import db
 from reciperadar.models.base import Storable
 
 
@@ -39,10 +39,10 @@ class BaseURL(Storable):
             kwargs['domain'] = domain
         super().__init__(*args, **kwargs)
 
-    url = Column(String, primary_key=True)
-    domain = Column(String)
-    crawled_at = Column(DateTime)
-    crawl_status = Column(Integer)
+    url = db.Column(db.String, primary_key=True)
+    domain = db.Column(db.String)
+    crawled_at = db.Column(db.DateTime)
+    crawl_status = db.Column(db.Integer)
 
     @abstractmethod
     def _make_request(self):
@@ -72,7 +72,7 @@ class BaseURL(Storable):
 class CrawlURL(BaseURL):
     __tablename__ = 'crawl_urls'
 
-    resolves_to = Column(String, index=True)
+    resolves_to = db.Column(db.String, index=True)
 
     def _make_request(self):
         response = requests.post(

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -1,5 +1,3 @@
-from sqlalchemy.orm import aliased
-
 from reciperadar import db
 from reciperadar.models.recipes import Recipe
 from reciperadar.models.url import CrawlURL, RecipeURL
@@ -39,7 +37,7 @@ def find_earliest_crawl(url):
         .cte(recursive=True)
     )
 
-    previous_step = aliased(earliest_crawl)
+    previous_step = db.aliased(earliest_crawl)
     earliest_crawl = earliest_crawl.union_all(
         db.session.query(
             CrawlURL.crawled_at,
@@ -68,7 +66,7 @@ def find_latest_crawl(url):
         .cte(recursive=True)
     )
 
-    previous_step = aliased(latest_crawl)
+    previous_step = db.aliased(latest_crawl)
     latest_crawl = latest_crawl.union_all(
         db.session.query(
             CrawlURL.crawled_at,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Following the changes in #8, we can use the `reciperadar.db` object to refer to various `sqlalchemy` class definitions, saving a large number of module import references for brevity.

**List any issues that this change relates to**
Relates to #8 
