### PR TITLE
Autosuggest: generate edge ngrams over ingredient names

### DIFF
--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -43,6 +43,11 @@ class IngredientProduct(Storable):
             contents=contents
         )
 
+    def to_doc(self):
+        doc = super().to_doc()
+        doc['product_autocomplete'] = doc['product']
+        return doc
+
     def state(self, include):
         states = {
             True: IngredientProduct.STATE_AVAILABLE,

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -43,11 +43,6 @@ class IngredientProduct(Storable):
             contents=contents
         )
 
-    def to_doc(self):
-        doc = super().to_doc()
-        doc['product_autocomplete'] = doc['product']
-        return doc
-
     def state(self, include):
         states = {
             True: IngredientProduct.STATE_AVAILABLE,

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -90,8 +90,10 @@ args = parser.parse_args()
 
 es = Elasticsearch(args.hostname)
 try:
+    es.indices.close(index=args.index)
     es.indices.put_settings(index=args.index, body=settings)
     es.indices.put_mapping(index=args.index, body=mapping)
+    es.indices.open(index=args.index)
 except Exception as e:
     print('Failed to create recipe index: {}'.format(e))
     sys.exit(1)

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -6,6 +6,32 @@ settings = {
     'index': {
         'number_of_replicas': 0,
         'refresh_interval': '300s',
+    },
+    'analysis': {
+        'analyzer': {
+            'autocomplete.analyze': {
+                'tokenizer': 'autocomplete.tokenize',
+                'filter': ['lowercase']
+            },
+            'autocomplete.search': {
+                'tokenizer': 'lowercase',
+                'filter': ['autocomplete.filter']
+            }
+        },
+        'filter': {
+            'autocomplete.filter': {
+                'type': 'truncate',
+                'length': 10
+            }
+        }
+        'tokenizer': {
+            'autocomplete.tokenize': {
+                'type': 'edge_ngram',
+                'min_ngram': 3,
+                'max_ngram': 10,
+                'token_chars': ['letter']
+            }
+        }
     }
 }
 mapping = {
@@ -36,6 +62,11 @@ mapping = {
                     'properties': {
                         'product_id': {'type': 'keyword'},
                         'product': {'type': 'text'},
+                        'product.autocomplete': {
+                            'type': 'text',
+                            'analyzer': 'autocomplete.analyze',
+                            'search_analyzer': 'autocomplete.search'
+                        },
                         'category': {'type': 'keyword'},
                         'is_plural': {'type': 'boolean'},
                         'singular': {'type': 'keyword'},

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -61,11 +61,15 @@ mapping = {
                 'product': {
                     'properties': {
                         'product_id': {'type': 'keyword'},
-                        'product': {'type': 'text'},
-                        'product_autocomplete': {
+                        'product': {
                             'type': 'text',
-                            'analyzer': 'autocomplete_analyze',
-                            'search_analyzer': 'autocomplete_search'
+                            'fields': {
+                                'autocomplete': {
+                                    'type': 'text',
+                                    'analyzer': 'autocomplete_analyze',
+                                    'search_analyzer': 'autocomplete_search'
+                                }
+                            }
                         },
                         'category': {'type': 'keyword'},
                         'is_plural': {'type': 'boolean'},

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -23,7 +23,7 @@ settings = {
                 'type': 'truncate',
                 'length': 10
             }
-        }
+        },
         'tokenizer': {
             'autocomplete.tokenize': {
                 'type': 'edge_ngram',

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -62,7 +62,7 @@ mapping = {
                     'properties': {
                         'product_id': {'type': 'keyword'},
                         'product': {
-                            'type': 'text',
+                            'type': 'keyword',
                             'fields': {
                                 'autocomplete': {
                                     'type': 'text',

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -2,6 +2,12 @@ import argparse
 from elasticsearch import Elasticsearch
 import sys
 
+settings = {
+    'index': {
+        'number_of_replicas': 0,
+        'refresh_interval': '300s',
+    }
+}
 mapping = {
     'properties': {
         'directions': {
@@ -39,12 +45,6 @@ mapping = {
             }
         },
         'contents': {'type': 'keyword'}
-    }
-}
-settings = {
-    'index': {
-        'number_of_replicas': 0,
-        'refresh_interval': '300s',
     }
 }
 

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -55,8 +55,8 @@ args = parser.parse_args()
 
 es = Elasticsearch(args.hostname)
 try:
-    es.indices.put_mapping(index=args.index, body=mapping)
     es.indices.put_settings(index=args.index, body=settings)
+    es.indices.put_mapping(index=args.index, body=mapping)
 except Exception as e:
     print('Failed to create recipe index: {}'.format(e))
     sys.exit(1)

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -9,26 +9,26 @@ settings = {
     },
     'analysis': {
         'analyzer': {
-            'autocomplete.analyze': {
-                'tokenizer': 'autocomplete.tokenize',
+            'autocomplete_analyze': {
+                'tokenizer': 'autocomplete_tokenize',
                 'filter': ['lowercase']
             },
-            'autocomplete.search': {
-                'tokenizer': 'lowercase',
-                'filter': ['autocomplete.filter']
+            'autocomplete_search': {
+                'tokenizer': 'standard',
+                'filter': ['lowercase', 'autocomplete_filter']
             }
         },
         'filter': {
-            'autocomplete.filter': {
+            'autocomplete_filter': {
                 'type': 'truncate',
                 'length': 10
             }
         },
         'tokenizer': {
-            'autocomplete.tokenize': {
+            'autocomplete_tokenize': {
                 'type': 'edge_ngram',
-                'min_ngram': 3,
-                'max_ngram': 10,
+                'min_gram': 3,
+                'max_gram': 10,
                 'token_chars': ['letter']
             }
         }
@@ -62,10 +62,10 @@ mapping = {
                     'properties': {
                         'product_id': {'type': 'keyword'},
                         'product': {'type': 'text'},
-                        'product.autocomplete': {
+                        'product_autocomplete': {
                             'type': 'text',
-                            'analyzer': 'autocomplete.analyze',
-                            'search_analyzer': 'autocomplete.search'
+                            'analyzer': 'autocomplete_analyze',
+                            'search_analyzer': 'autocomplete_search'
                         },
                         'category': {'type': 'keyword'},
                         'is_plural': {'type': 'boolean'},


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The Elasticsearch [edge n-gram tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/analysis-edgengram-tokenizer.html) provides a useful base onto which we can build typo-tolerant search.

By using the tokenizer to generate ngrams of length 3-10 characters, we can prime the search index with terms that should cover most user-input ingredient name substrings completely.

The upper bound of 10 is chosen fairly arbitrarily, with the goal of keeping the index size manageable.  Ingredient names entered by the user are similarly truncated to 10 characters in order to match the indexed terms.

### Briefly summarize the changes
1. Add `ingredient.product.product.autocomplete` edge-ngram tokenized multi-field

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Relates to openculinary/api#20
