### PR TITLE
 Refactor: rectify magnitude property name on ingredient objects

### DIFF
--- a/migrations/versions/8f39b3c75033_.py
+++ b/migrations/versions/8f39b3c75033_.py
@@ -1,0 +1,26 @@
+"""recipe_ingredients.quantity* -> recipe_ingredients.magnitude*
+
+Revision ID: 8f39b3c75033
+Revises: 
+Create Date: 2020-06-28 16:09:49.000760
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '8f39b3c75033'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('recipe_ingredients', 'quantity_parser', new_column_name='magnitude_parser')
+    op.alter_column('recipe_ingredients', 'quantity', new_column_name='magnitude')
+
+
+def downgrade():
+    op.alter_column('recipe_ingredients', 'magnitude_parser', new_column_name='quantity_parser')
+    op.alter_column('recipe_ingredients', 'magnitude', new_column_name='quantity')

--- a/migrations/versions/8f39b3c75033_.py
+++ b/migrations/versions/8f39b3c75033_.py
@@ -1,13 +1,10 @@
 """recipe_ingredients.quantity* -> recipe_ingredients.magnitude*
 
 Revision ID: 8f39b3c75033
-Revises: 
 Create Date: 2020-06-28 16:09:49.000760
 
 """
 from alembic import op
-import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '8f39b3c75033'
@@ -17,10 +14,26 @@ depends_on = None
 
 
 def upgrade():
-    op.alter_column('recipe_ingredients', 'quantity_parser', new_column_name='magnitude_parser')
-    op.alter_column('recipe_ingredients', 'quantity', new_column_name='magnitude')
+    op.alter_column(
+        table='recipe_ingredients',
+        column='quantity_parser',
+        new_column_name='magnitude_parser'
+    )
+    op.alter_column(
+        table='recipe_ingredients',
+        column='quantity',
+        new_column_name='magnitude'
+    )
 
 
 def downgrade():
-    op.alter_column('recipe_ingredients', 'magnitude_parser', new_column_name='quantity_parser')
-    op.alter_column('recipe_ingredients', 'magnitude', new_column_name='quantity')
+    op.alter_column(
+        table='recipe_ingredients',
+        column='magnitude_parser',
+        new_column_name='quantity_parser'
+    )
+    op.alter_column(
+        table='recipe_ingredients',
+        column='magnitude',
+        new_column_name='quantity'
+    )

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -46,8 +46,10 @@ class RecipeIngredient(Storable, Searchable):
         return {
             'markup': self.markup,
             'product': self.product.to_dict(include),
-            'quantity': self.quantity,
-            'units': self.units,
+            'quantity': {
+                'magnitude': self.quantity,
+                'units': self.units,
+            }
         }
 
     def to_doc(self):

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -20,8 +20,8 @@ class RecipeIngredient(Storable, Searchable):
         passive_deletes='all'
     )
 
-    quantity = db.Column(db.Float)
-    quantity_parser = db.Column(db.String)
+    magnitude = db.Column(db.Float)
+    magnitude_parser = db.Column(db.String)
     units = db.Column(db.String)
     units_parser = db.Column(db.String)
     verb = db.Column(db.String)
@@ -35,8 +35,10 @@ class RecipeIngredient(Storable, Searchable):
             description=doc['description'].strip(),
             markup=doc.get('markup'),
             product=IngredientProduct.from_doc(doc['product']),
-            quantity=doc.get('quantity'),
-            quantity_parser=doc.get('quantity_parser'),
+            magnitude=doc.get('magnitude') or doc.get('quantity'),  # TODO
+            magnitude_parser=(
+                doc.get('magnitude_parser') or doc.get('quantity_parser')
+            ),  # TODO
             units=doc.get('units'),
             units_parser=doc.get('units_parser'),
             verb=doc.get('verb')
@@ -47,7 +49,7 @@ class RecipeIngredient(Storable, Searchable):
             'markup': self.markup,
             'product': self.product.to_dict(include),
             'quantity': {
-                'magnitude': self.quantity,
+                'magnitude': self.magnitude,
                 'units': self.units,
             }
         }

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -46,6 +46,8 @@ class RecipeIngredient(Storable, Searchable):
         return {
             'markup': self.markup,
             'product': self.product.to_dict(include),
+            'quantity': self.quantity,
+            'units': self.units,
         }
 
     def to_doc(self):

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -55,7 +55,6 @@ class IngredientProduct(Storable):
         return {
             'product_id': self.product_id,
             'product': self.product,
-            'value': self.product,
             'category': self.category,
             'singular': self.singular,
             'plural': self.plural,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a minor terminology consistency change; throughout the application's codebase, a `quantity` object should consist of a `magnitude` field and a `units` field.