### PR TITLE
Add recipe diagnostics endpoint

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -25,7 +25,7 @@ def recipe_diagnostics(recipe_id):
     return jsonify({
         'id': recipe.id,
         'indexed_at': recipe.indexed_at,
-        'current_crawl': {
+        'latest_crawl': {
             'url': recipe_url.url,
             'crawled_at': recipe_url.crawled_at,
             'crawl_status': recipe_url.crawl_status,

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -1,4 +1,5 @@
 from flask import abort, jsonify, request
+import requests
 
 from reciperadar import app
 from reciperadar.models.recipes import Recipe
@@ -25,6 +26,7 @@ def recipe_diagnostics(recipe_id):
     return jsonify({
         'id': recipe.id,
         'indexed_at': recipe.indexed_at,
+        'current_crawl': recipe_url.crawl().json(),
         'latest_crawl': {
             'url': recipe_url.url,
             'crawled_at': recipe_url.crawled_at,

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -13,6 +13,34 @@ def recipe_get(recipe_id):
     return jsonify(recipe.to_doc())
 
 
+@app.route('/api/recipes/<recipe_id>/diagnostics')
+def recipe_diagnostics(recipe_id):
+    recipe = Recipe().get_by_id(recipe_id)
+    if not recipe:
+        return abort(404)
+
+    recipe_url = recipe.recipe_url
+    earliest_crawl = recipe_url.find_earliest_crawl()
+
+    return jsonify({
+        'id': recipe.id,
+        'indexed_at': recipe.indexed_at,
+        'current_crawl': {
+            'url': recipe_url.url,
+            'crawled_at': recipe_url.crawled_at,
+            'crawl_status': recipe_url.crawl_status,
+            'crawler_version': recipe_url.crawler_version,
+            'recipe_scrapers_version': recipe_url.recipe_scrapers_version,
+        },
+        'earliest_crawl': {
+            'url': earliest_crawl.url,
+            'crawled_at': earliest_crawl.crawled_at,
+            'crawl_status': recipe_url.crawl_status,
+            'crawler_version': recipe_url.crawler_version,
+        },
+    })
+
+
 @app.route('/api/recipes/crawl', methods=['POST'])
 def recipe_crawl():
     url = request.form.get('url')

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -15,7 +15,7 @@ def recipe_get(recipe_id):
 
 @app.route('/api/recipes/<recipe_id>/diagnostics')
 def recipe_diagnostics(recipe_id):
-    recipe = Recipe().get_by_id(recipe_id)
+    recipe = Recipe.query.get(recipe_id)
     if not recipe:
         return abort(404)
 

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -1,5 +1,4 @@
 from flask import abort, jsonify, request
-import requests
 
 from reciperadar import app
 from reciperadar.models.recipes import Recipe

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -4,6 +4,7 @@ from reciperadar import db
 from reciperadar.models.base import Searchable, Storable
 from reciperadar.models.recipes.direction import RecipeDirection
 from reciperadar.models.recipes.ingredient import RecipeIngredient
+from reciperadar.models.url import RecipeURL
 
 
 class Recipe(Storable, Searchable):
@@ -53,6 +54,10 @@ class Recipe(Storable, Searchable):
             if not ingredient.product.singular:
                 return True
         return False
+
+    @property
+    def recipe_url(self):
+        return db.session.query(RecipeURL).get(self.dst)
 
     @staticmethod
     def from_doc(doc):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As part of openculinary/frontend#94, we want to provide access to debug information about recipe content in the application.

This data is not required for typical user interaction with the application, and should be required rarely.  These factors mean that we should avoid affecting the performance and capacity of the recipe search engine, and can provide the data from the `backend` service which has lower uptime requirements than the user-facing `api` service.

### Briefly summarize the changes
1. Add a recipe diagnostics endpoint to the service at `/api/recipes/<id>/diagnostics`

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Relates to openculinary/frontend#94