### PR TITLE
Architecture adjustment: provide separate current-crawl, indexed-data and historic-metadata endpoints

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -46,7 +46,10 @@ def recipe_crawl_retrieve(recipe_id):
     recipe = Recipe.query.get(recipe_id)
     if not recipe:
         return abort(404)
-    return jsonify(recipe.recipe_url.crawl().json())
+
+    recipe_data = recipe.recipe_url.crawl().json()['recipe']
+    recipe = Recipe.from_doc(recipe_data)
+    return jsonify()
 
 
 @app.route('/recipes/crawl', methods=['POST'])

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -25,7 +25,6 @@ def recipe_diagnostics(recipe_id):
     return jsonify({
         'id': recipe.id,
         'indexed_at': recipe.indexed_at,
-        'current_crawl': recipe_url.crawl().json(),
         'latest_crawl': {
             'url': recipe_url.url,
             'crawled_at': recipe_url.crawled_at,

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -13,7 +13,7 @@ def recipe_get(recipe_id):
     return jsonify(recipe.to_doc())
 
 
-@app.route('/recipes/<recipe_id>/diagnostics')
+@app.route('/recipes/<recipe_id>/history')
 def recipe_diagnostics(recipe_id):
     recipe = Recipe.query.get(recipe_id)
     if not recipe:

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -48,6 +48,9 @@ def recipe_crawl_retrieve(recipe_id):
         return abort(404)
 
     recipe_data = recipe.recipe_url.crawl().json()['recipe']
+    recipe_data['src'] = recipe.src
+    recipe_data['dst'] = recipe.dst
+
     recipe = Recipe.from_doc(recipe_data)
     return jsonify(recipe.to_doc())
 

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -49,7 +49,7 @@ def recipe_crawl_retrieve(recipe_id):
 
     recipe_data = recipe.recipe_url.crawl().json()['recipe']
     recipe = Recipe.from_doc(recipe_data)
-    return jsonify()
+    return jsonify(recipe.to_doc())
 
 
 @app.route('/recipes/crawl', methods=['POST'])

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -41,8 +41,16 @@ def recipe_diagnostics(recipe_id):
     })
 
 
+@app.route('/recipes/<recipe_id>/crawl', methods=['GET'])
+def recipe_crawl_retrieve(recipe_id):
+    recipe = Recipe.query.get(recipe_id)
+    if not recipe:
+        return abort(404)
+    return jsonify(recipe.recipe_url.crawl().json())
+
+
 @app.route('/recipes/crawl', methods=['POST'])
-def recipe_crawl():
+def recipe_crawl_submit():
     url = request.form.get('url')
     if not url:
         return abort(400)

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -41,7 +41,7 @@ def recipe_diagnostics(recipe_id):
     })
 
 
-@app.route('/recipes/<recipe_id>/crawl', methods=['GET'])
+@app.route('/recipes/<recipe_id>/crawl')
 def recipe_crawl_retrieve(recipe_id):
     recipe = Recipe.query.get(recipe_id)
     if not recipe:


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently the `api` service does not rely at all on the `requests` library; that is, it has no ability (nor need) to make remote service calls.  From a robustness and architecture isolation point of view, that's great - it is self-contained and can service user demand as long as it and the search engine it relies upon are operational.  In future it may even be possible for those to run in a read-only environment.

However, for recipe debug purposes we do need to expose a recipe diagnostics HTTP endpoint to the `frontend` application, and that will require the involvement of the `backend` (database) service since that's where we store the recipe metadata.  As discussed in #17, this doesn't require high availability.

Bearing these two constraints in mind, a sensible architecture appears: we can spin up a small new `diagnostics` service, with non-critical uptime requirements, and allow this service to access the `backend` metadata endpoints.

This service can perform the necessary logic to collate and transform the recipe content metadata into a format for the `frontend` application to display in a diagnostics view.

A key benefit of this is that we can open up public access to the `diagnostics` service via `haproxy` (the same way we [provide `api` service access](https://github.com/openculinary/infrastructure/blob/7c3ad7d2aa35610059267112c272166852b59f84/etc/haproxy/haproxy.cfg#L23)) and we can be assured that other internal `backend` service endpoints are not directly accessible by users.

This also seems to fit the conceptual notion of microservices: a `diagnostics` service has a single self-describing purpose, which is to provide contextual information to support staff in order to trace the potential cause of system/data problems.

### Briefly summarize the changes
1. Move real-time crawl requests to a newly-introduced `GET /recipes/<recipe_id>/crawl` endpoint
1. Rename the recipe `diagnostics` endpoint to `history` since it now performs a more narrowly-defined role