### PR TITLE
Refactor: extract equipment objects from direction markup

### DIFF
--- a/reciperadar/models/recipes/direction.py
+++ b/reciperadar/models/recipes/direction.py
@@ -1,3 +1,5 @@
+from xml.etree import ElementTree
+
 from reciperadar import db
 from reciperadar.models.base import Storable
 from reciperadar.models.recipes.appliance import DirectionAppliance
@@ -32,25 +34,49 @@ class RecipeDirection(Storable):
     )
 
     @staticmethod
+    def _build_item(item, category, category_class):
+        item_classes = set(item.attrib.get('class', '').split())
+        if 'equipment' not in item_classes:
+            return
+        if category not in item_classes:
+            return
+        doc = {category: item.text}
+        return category_class.from_doc(doc)
+
+    @staticmethod
+    def _parse_equipment(markup):
+        equipment = {
+            'appliances': [],
+            'utensils': [],
+            'vessels': [],
+        }
+        if not markup:
+            return equipment
+
+        category_classes = {
+            'appliances': DirectionAppliance,
+            'utensils': DirectionUtensil,
+            'vessels': DirectionVessel,
+        }
+
+        doc = ElementTree.fromstring(f'<xml>{markup}</xml>')
+        for item in doc.findall('mark'):
+            for category in equipment:
+                cls = category_classes[category]
+                obj = RecipeDirection._build_item(item, category[:-1], cls)
+                equipment[category].append(obj) if obj else None
+        return equipment
+
+    @staticmethod
     def from_doc(doc, matches=None):
         direction_id = doc.get('id') or RecipeDirection.generate_id()
+        equipment = RecipeDirection._parse_equipment(doc['markup'])
         return RecipeDirection(
             id=direction_id,
             index=doc.get('index'),  # TODO
             description=doc['description'],
-            markup=doc.get('markup'),
-            appliances=[
-                DirectionAppliance.from_doc(appliance)
-                for appliance in doc.get('appliances', [])
-            ],
-            utensils=[
-                DirectionUtensil.from_doc(utensil)
-                for utensil in doc.get('utensils', [])
-            ],
-            vessels=[
-                DirectionVessel.from_doc(vessel)
-                for vessel in doc.get('vessels', [])
-            ]
+            markup=doc['markup'],
+            **equipment
         )
 
     def to_doc(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,21 +26,11 @@ def raw_recipe_hit():
                 {
                     "index": 0,
                     "description": "place each skewer in the oven",
-                    "appliances": [
-                        {
-                            "appliance": "oven"
-                        }
-                    ],
-                    "utensils": [
-                        {
-                            "utensil": "skewer"
-                        }
-                    ],
-                    "vessels": [
-                        {
-                            "vessel": "casserole dish"
-                        }
-                    ]
+                    "markup": (
+                        "<mark class='action'>place</mark> each "
+                        "<mark class='equipment utensil'>skewer</mark> in the "
+                        "<mark class='equipment appliance'>oven</mark>"
+                    )
                 }
             ],
             "ingredients": [

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -6,7 +6,6 @@ def test_recipe_from_doc(raw_recipe_hit):
 
     assert recipe.directions[0].appliances[0].appliance == 'oven'
     assert recipe.directions[0].utensils[0].utensil == 'skewer'
-    assert recipe.directions[0].vessels[0].vessel == 'casserole dish'
 
     assert recipe.ingredients[0].product.product == 'one'
     expected_contents = ['one', 'content-of-one', 'ancestor-of-one']


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The `knowledge-graph` no longer returns separate response fields for different types of equipment (`appliances`, `utensils`, ...), since the number of entity references is increasing and it seems to make sense to bundle all of the metadata inline in the `markup` XML field (see openculinary/knowledge-graph#45 for background).

As a result the backend service should construct these objects directly based on the contents of the `markup` field.

### Briefly summarize the changes
1. Parse and construct equipment objects based on the XML `markup` field for each recipe direction

### How have the changes been tested?
1. Unit test coverage is updated to reflect the updated parsing expectations

**List any issues that this change relates to**
Relates to openculinary/knowledge-graph#45