### PR TITLE
[performance] Switch celery workers to use gevent pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ image:
 	$(eval container=$(shell buildah from docker.io/library/python:3.8-alpine))
 	buildah copy $(container) 'reciperadar' 'reciperadar'
 	buildah copy $(container) 'Pipfile'
+	buildah run $(container) -- apk add py3-gevent --
 	buildah run $(container) -- adduser -h /srv/ -s /sbin/nologin -D -H gunicorn --
 	buildah run $(container) -- chown gunicorn /srv/ --
 	buildah run --user gunicorn $(container) -- pip install --user pipenv --

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -21,3 +21,6 @@ spec:
         name: backend
         command: ['/srv/.local/bin/pipenv']
         args: ['run', 'celery', '-A', 'reciperadar.workers', 'worker', '-Q', 'celery,crawl_url,crawl_recipe,process_recipe,index_recipe,recrawl_search']
+        env:
+        - name: 'PYTHONPATH'
+          value: '/usr/lib/python3.8/site-packages'

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: backend
         command: ['/srv/.local/bin/pipenv']
-        args: ['run', 'celery', '-A', 'reciperadar.workers', '-P', 'gevent', 'worker', '-Q', 'celery,crawl_url,crawl_recipe,process_recipe,index_recipe,recrawl_search']
+        args: ['run', 'celery', '-A', 'reciperadar.workers', 'worker', '-P', 'gevent', '-Q', 'celery,crawl_url,crawl_recipe,process_recipe,index_recipe,recrawl_search']
         env:
         - name: 'PYTHONPATH'
           value: '/usr/lib/python3.8/site-packages'

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         imagePullPolicy: IfNotPresent
         name: backend
         command: ['/srv/.local/bin/pipenv']
-        args: ['run', 'celery', '-A', 'reciperadar.workers', 'worker', '-Q', 'celery,crawl_url,crawl_recipe,process_recipe,index_recipe,recrawl_search']
+        args: ['run', 'celery', '-A', 'reciperadar.workers', '-P', 'gevent', 'worker', '-Q', 'celery,crawl_url,crawl_recipe,process_recipe,index_recipe,recrawl_search']
         env:
         - name: 'PYTHONPATH'
           value: '/usr/lib/python3.8/site-packages'

--- a/reciperadar/__init__.py
+++ b/reciperadar/__init__.py
@@ -14,8 +14,7 @@ def create_app(db_uri='postgresql+pg8000://api@postgresql/api'):
 
 def create_db(app):
     db = SQLAlchemy(app, session_options={
-        'autoflush': False,
-        'expire_on_commit': False,
+        'autoflush': False
     })
     return db
 

--- a/reciperadar/__init__.py
+++ b/reciperadar/__init__.py
@@ -14,7 +14,8 @@ def create_app(db_uri='postgresql+pg8000://api@postgresql/api'):
 
 def create_db(app):
     db = SQLAlchemy(app, session_options={
-        'autoflush': False
+        'autoflush': False,
+        'expire_on_commit': False,
     })
     return db
 

--- a/reciperadar/workers/broker.py
+++ b/reciperadar/workers/broker.py
@@ -1,3 +1,5 @@
 from celery import Celery
+from celery.signals import task_postrun
 
 celery = Celery('reciperadar', broker='pyamqp://guest@rabbitmq')
+postrun = task_postrun

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -2,7 +2,12 @@ from reciperadar import db
 from reciperadar.models.recipes import Recipe
 from reciperadar.models.domain import Domain
 from reciperadar.models.url import CrawlURL, RecipeURL
-from reciperadar.workers.broker import celery
+from reciperadar.workers.broker import celery, postrun
+
+
+@postrun.connect
+def cleanup(task_id, task, *args, **kwargs):
+    db.session.close()
 
 
 @celery.task(queue='index_recipe')


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The `celery` task workers are mostly network I/O bound - that is, they spend most of their time waiting for remote service calls (to the `crawler` and `elasticsearch` in particular) to complete.

To increase overall system recipe indexing throughput, this change switches the worker process pool to use `gevent` which is more suited to I/O bound workloads.

### Briefly summarize the changes
1. Add the `py3-gevent` Alpine Linux dependency to the container image
1. Run `celery` workers using the `gevent` pool
1. Add task post-run database cleanup step

### How have the changes been tested?
1. Local development testing