### PR TITLE
Update representation of ingredients in the search index 

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -45,6 +45,13 @@ class RecipeIngredient(Storable, Searchable):
         if self.units == 'ml':
             return self.magnitude / self.relative_density
 
+    @property
+    def product_name(self):
+        if self.product_is_plural:
+            return self.product.plural
+        else:
+            return self.product.singular
+
     @staticmethod
     def from_doc(doc):
         ingredient_id = doc.get('id') or RecipeIngredient.generate_id()
@@ -70,5 +77,6 @@ class RecipeIngredient(Storable, Searchable):
     def to_doc(self):
         data = super().to_doc()
         data['product'] = self.product.to_doc() if self.product else None
+        data['product_name'] = self.product_name if self.product else None
         data['nutrition'] = self.nutrition.to_doc() if self.nutrition else None
         return data

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -60,21 +60,21 @@ mapping = {
             'properties': {
                 'product': {
                     'properties': {
-                        'product_id': {'type': 'keyword'},
-                        'product': {
-                            'type': 'keyword',
-                            'fields': {
-                                'autocomplete': {
-                                    'type': 'text',
-                                    'analyzer': 'autocomplete_analyze',
-                                    'search_analyzer': 'autocomplete_search'
-                                }
-                            }
-                        },
+                        'id': {'type': 'keyword'},
                         'category': {'type': 'keyword'},
-                        'is_plural': {'type': 'boolean'},
                         'singular': {'type': 'keyword'},
                         'plural': {'type': 'keyword'},
+                    }
+                },
+                'product_is_plural': {'type': 'boolean'},
+                'product_name': {
+                    'type': 'keyword',
+                    'fields': {
+                        'autocomplete': {
+                            'type': 'text',
+                            'analyzer': 'autocomplete_analyze',
+                            'search_analyzer': 'autocomplete_search'
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Following some of the recent database normalization changes (see #35, #36, #37), this changeset updates the representation of ingredients within the Elasticsearch search index.

### Briefly summarize the changes
1. `product.product_id` field is renamed to `product.id` (rationale: the word 'product' is implied)
1. `ingredient.product.is_plural` field is renamed to `ingredient.product_is_plural` (rationale: an abstract product only takes a singular/plural form concretely inside the written context of an ingredient)
1. `ingredient.product.product` field is renamed to `ingredient.product_name` (rationale: this is more comprehensible)

### How have the changes been tested?
1. Manual inspection of search index documents following reindexing of content

**List any issues that this change relates to**
Progresses #34.
Inspired #38.