### PR TITLE
Introduce experimental unit test database transactional safety fixture

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,4 +2,3 @@
 flake8
 pytest
 responses
-pytest-flask-sqlalchemy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -91,7 +91,6 @@ flask-sqlalchemy==2.5.1 \
     # via
     #   -r requirements.txt
     #   flask-migrate
-    #   pytest-flask-sqlalchemy
 flask==1.1.2 \
     --hash=sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060 \
     --hash=sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557
@@ -254,9 +253,7 @@ mccabe==0.6.1 \
 packaging==20.9 \
     --hash=sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5 \
     --hash=sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
-    # via
-    #   pytest
-    #   pytest-flask-sqlalchemy
+    # via pytest
 pg8000==1.19.4 \
     --hash=sha256:510db12be8ad85488289bd0b97bc340202cf6749da08cf8588032a047fb5d0ba \
     --hash=sha256:7c9c6d57541b0f2153e23a8d759ceb3d7cb9308918fba6ad9e92f8e0e5a90bc8
@@ -290,21 +287,10 @@ pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
     # via packaging
-pytest-flask-sqlalchemy==1.0.2 \
-    --hash=sha256:19cad31d654c2301dd2dd70d06a62e5dc4ea380500f4b89bbcb3d59a475f0cf6 \
-    --hash=sha256:34fa0f9a63c3892f54a8d11ab67f907c0e0911ac609e3cff5d518c3af6b897cd
-    # via -r requirements-dev.in
-pytest-mock==3.6.1 \
-    --hash=sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3 \
-    --hash=sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62
-    # via pytest-flask-sqlalchemy
 pytest==6.2.4 \
     --hash=sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b \
     --hash=sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890
-    # via
-    #   -r requirements-dev.in
-    #   pytest-flask-sqlalchemy
-    #   pytest-mock
+    # via -r requirements-dev.in
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
@@ -383,7 +369,6 @@ sqlalchemy==1.4.14 \
     #   -r requirements.txt
     #   alembic
     #   flask-sqlalchemy
-    #   pytest-flask-sqlalchemy
 tld==0.12.5 \
     --hash=sha256:1a69b2cd4053da5377a0b27e048e97871120abf9cd7a62ff270915d0c11369d6 \
     --hash=sha256:1b63094d893657eadfd61e49580b4225ce958ca3b8013dbb9485372cde5a3434 \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from sqlalchemy import event
 
-from reciperadar import app, create_db
+from reciperadar import app, db as app_db
 from reciperadar.models.recipes.product import Product
 
 
@@ -13,7 +13,7 @@ def client():
 
 @pytest.fixture
 def db():
-    return create_db(app)
+    return app_db
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from sqlalchemy import event
+
 from reciperadar import app, create_db
 from reciperadar.models.recipes.product import Product
 
@@ -10,11 +12,33 @@ def client():
 
 
 @pytest.fixture
-def _db():
-    # TODO: Restore db isolation testing after pytest-flask-sqlalchemy
-    # introduces support for sqlalchemy 1.4
-    pytest.skip()
+def db():
     return create_db(app)
+
+
+@pytest.fixture
+def connection(db):
+    return db.engine.connect()
+
+
+@pytest.fixture
+def db_session(db, connection):
+    transaction = connection.begin()
+    db.session = db.create_scoped_session(options={"bind": connection, "binds": {}})
+    db.session.begin_nested()
+
+    # for handling tests that actually call "session.rollback()"
+    # https://docs.sqlalchemy.org/en/13/orm/session_transaction.html#joining-a-session-into-an-external-transaction-such-as-for-test-suites
+    @event.listens_for(db.session, "after_transaction_end")
+    def restart_savepoint(session, transaction_in):
+        if transaction_in.nested and not transaction_in._parent.nested:
+            session.expire_all()
+            session.begin_nested()
+
+    yield db.session
+
+    db.session.close()
+    transaction.rollback()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 from sqlalchemy import event
 
-from reciperadar import app, db as app_db
+from reciperadar import app, db
 from reciperadar.models.recipes.product import Product
 
 
@@ -12,17 +12,12 @@ def client():
 
 
 @pytest.fixture
-def db():
-    return app_db
-
-
-@pytest.fixture
-def connection(db):
+def connection():
     return db.engine.connect()
 
 
 @pytest.fixture
-def db_session(db, connection):
+def db_session(connection):
     """
     Sourced from https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/46#issuecomment-829694672  # noqa
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,10 @@ def connection(db):
 
 @pytest.fixture
 def db_session(db, connection):
+    db_session_options = {"bind": connection, "binds": {}}
+
     transaction = connection.begin()
-    db.session = db.create_scoped_session(options={"bind": connection, "binds": {}})
+    db.session = db.create_scoped_session(options=db_session_options)
     db.session.begin_nested()
 
     # for handling tests that actually call "session.rollback()"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,9 @@ def connection(db):
 
 @pytest.fixture
 def db_session(db, connection):
+    """
+    Sourced from https://github.com/jeancochrane/pytest-flask-sqlalchemy/issues/46#issuecomment-829694672  # noqa
+    """
     db_session_options = {"bind": connection, "binds": {}}
 
     transaction = connection.begin()

--- a/tests/setup.cfg
+++ b/tests/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-mocked-sessions=reciperadar.db.session


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset introduces a concise `db_session` `pytest` fixture that provides database transactional safety during unit testing.

Many thanks to @itajaja for providing the code and suggestion to implement this change.

If this works out well for the codebase, the plan is to create a shared Python package to allow others to re-use the fixture.

### Briefly summarize the changes
1. Add the `db_session` `pytest` fixture (NB: `autouse` is not enabled by default here)

### How have the changes been tested?
1. Local development testing