### PR TITLE
Improve the performance of the recipe product admin interface

### DIFF
--- a/reciperadar/admin/products.py
+++ b/reciperadar/admin/products.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 from flask_admin.contrib.sqla import ModelView
 
 from reciperadar import admin_app, db
@@ -38,6 +40,16 @@ class ProductAdmin(ModelView):
 
     def __init__(self):
         super().__init__(Product, db.session)
+
+    def get_list(self, page, sort_column, sort_desc, search, filters,
+                 execute=True, page_size=None):
+        results = []
+        sources = deque(Product.query.filter(Product.parent_id == None))
+        while sources:
+            product = sources.popleft()
+            results.append(product)
+            sources.extendleft(product.get_children())
+        return len(results), results
 
     def on_model_change(self, form, model, is_created):
         model.id = model.singular.replace(' ', '_')

--- a/reciperadar/admin/products.py
+++ b/reciperadar/admin/products.py
@@ -44,11 +44,15 @@ class ProductAdmin(ModelView):
     def get_list(self, page, sort_column, sort_desc, search, filters,
                  execute=True, page_size=None):
         results = []
-        sources = deque(Product.query.filter(Product.parent_id == None))
+        sources = deque(
+            Product.query.filter(Product.parent_id == None).order_by(Product.id)
+        )
         while sources:
             product = sources.popleft()
             results.append(product)
-            sources.extendleft(product.get_children())
+            children = list(product.get_children())
+            children.reverse()  # counteract the reverse-insertion-order of deque.extendleft
+            sources.extendleft(children)
         return len(results), results
 
     def on_model_change(self, form, model, is_created):

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -37,7 +37,7 @@ class Product(Storable):
         return self.id
 
     def get_children(self):
-        return Product.query.filter(Product.parent_id == self.id)
+        return Product.query.filter(Product.parent_id == self.id).order_by(Product.id)
 
     @cached_property
     def ancestors(self):

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -36,6 +36,9 @@ class Product(Storable):
     def __str__(self):
         return self.id
 
+    def get_children(self):
+        return Product.query.filter(Product.parent_id == self.id)
+
     @cached_property
     def ancestors(self):
         results = set()

--- a/reciperadar/templates/admin/products.html
+++ b/reciperadar/templates/admin/products.html
@@ -8,6 +8,9 @@
     .col-parent_id {
         display: none;
     }
+    table.model-list td span.indent {
+        white-space: no-wrap;
+    }
     </style>
 {% endblock %}
 
@@ -33,9 +36,6 @@
           var parentId = $(this).find('.col-parent_id').text().trim();
           $(this).data('tt-parent-id', parentId);
         })
-
-        // Prevent wrapping within the item checkbox selection column
-        $('table.model-list td input.action-checkbox').parent().css('white-space', 'nowrap');
 
         // Re-render the table nodes in tree format
         $('table.model-list').treetable({

--- a/reciperadar/templates/admin/products.html
+++ b/reciperadar/templates/admin/products.html
@@ -4,6 +4,11 @@
     {{ super() }}
     <link href="{{ url_for('static', filename='jquery-ui.css') }}" rel="stylesheet" />
     <link href="{{ url_for('static', filename='jquery.treetable.css') }}" rel="stylesheet" />
+    <style>
+    .col-parent_id {
+        display: none;
+    }
+    </style>
 {% endblock %}
 
 {% block list_header %}
@@ -28,9 +33,6 @@
           var parentId = $(this).find('.col-parent_id').text().trim();
           $(this).data('tt-parent-id', parentId);
         })
-
-        // Remove the parent ID column from the table
-        $('table.model-list .col-parent_id').remove();
 
         // Prevent wrapping within the item checkbox selection column
         $('table.model-list td input.action-checkbox').parent().css('white-space', 'nowrap');

--- a/reciperadar/templates/admin/products.html
+++ b/reciperadar/templates/admin/products.html
@@ -43,13 +43,6 @@
           indent: 32,
         });
 
-        // Sort each root branch of the tree on the client; display order may differ
-        // from the HTML element ordering rendered onto the page by the server
-        $('table.model-list tr.branch').each(function() {
-          var node = $('table.model-list').treetable('node', $(this).data('tt-id'));
-          $('table.model-list').treetable('sortBranch', node);
-        });
-
         var applyExpansionIcons = function() {
           var expand = $(this).attr('title') === 'Expand';
           $(this).removeClass().addClass(expand ? 'icon-plus' : 'icon-minus');


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The recently-added recipe product admin interface (#52) was proving too slow for practical usage - taking a minute or so for each page load.

Here we apply some performance optimizations to bring the interface within acceptable -- albeit not yet ideal -- load times.

### Briefly summarize the changes
1. Pre-sort the table of products on the server-side so that the client does not have to sort every branch of products in the table using jQuery (expensive) before calling `treetable` to display the table as a tree
1. Move visual formatting from jQuery (slow in some cases, and performed after initial page render in the browser) into CSS (performed during page render by the browser - this also improves user experience since there is less 'jumping' of page elements on the page

### How have the changes been tested?
1. Running the page locally on a development machine with the [production copy of the recipe product table](https://github.com/openculinary/backend/blob/93cc432ce12d32e1a5cf60a63a955a08d89986d7/scripts/data/products.csv)

**List any issues that this change relates to**
Improves #52.