### PR TITLE
Export product.name entries during product hierarchy export

### DIFF
--- a/reciperadar/api/products.py
+++ b/reciperadar/api/products.py
@@ -15,28 +15,18 @@ def stream(items):
         yield f"{line}\n"
 
 
-def _product_map(products):
-    product_map = {}
+def _product_stream(products):
     for product, name, nutrition, count, plural_count in products.all():
-        product.name = name
-        product.nutrition = nutrition
-        product.count = count or 0
-        product.plural_count = plural_count or 0
-        product_map[product.id] = product
-    return product_map
-
-
-def _product_stream(product_map):
-    for product in product_map.values():
-        is_plural = product.plural_count > product.count - product.plural_count
+        plural_count = plural_count or 0
+        is_plural = plural_count > count - plural_count
         result = {
-            "product": product.name.plural if is_plural else product.name.singular,
-            "recipe_count": product.count,
+            "product": name.plural if is_plural else name.singular,
+            "recipe_count": count,
             "id": product.id,
             "parent_id": product.parent_id,
         }
-        if product.nutrition:
-            result["nutrition"] = product.nutrition.to_doc()
+        if nutrition:
+            result["nutrition"] = nutrition.to_doc()
         yield result
 
 
@@ -60,6 +50,5 @@ def hierarchy():
         )
     )
 
-    product_map = _product_map(products)
-    products = _product_stream(product_map)
+    products = _product_stream(products)
     return Response(stream(products), content_type="application/x-ndjson")

--- a/reciperadar/api/products.py
+++ b/reciperadar/api/products.py
@@ -26,23 +26,14 @@ def _product_map(products):
     return product_map
 
 
-def _calculate_depth(product_map, product):
-    if product.parent_id is None:
-        return 0
-    parent = product_map[product.parent_id]
-    return _calculate_depth(product_map, parent) + 1
-
-
 def _product_stream(product_map):
     for product in product_map.values():
-        depth = _calculate_depth(product_map, product)
         is_plural = product.plural_count > product.count - product.plural_count
         result = {
             "product": product.name.plural if is_plural else product.name.singular,
             "recipe_count": product.count,
             "id": product.id,
             "parent_id": product.parent_id,
-            "depth": depth,
         }
         if product.nutrition:
             result["nutrition"] = product.nutrition.to_doc()


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
With potentially multiple names stored in the database for each product, we need a way to export those names to the [`knowledge-graph`](https://github.com/openculinary/knowledge-graph/) so that they are used to discover ingredient names from recipes.

Rectification of field names (`product_id` -> `product_name_id`, for example) may occur in future.

### Briefly summarize the changes
1. Update the product hierarchy export so that it can contain multiple entries -- one per name -- for a single product

### How have the changes been tested?
1. Unit tests continue to pass

**List any issues that this change relates to**
Relates to #54.