### PR TITLE
Fairly-closely match flask's documentation regarding integration with celery

### DIFF
--- a/reciperadar/workers/broker.py
+++ b/reciperadar/workers/broker.py
@@ -1,3 +1,13 @@
-from celery import Celery
+from celery import Celery, Task
 
-celery = Celery("reciperadar", broker="pyamqp://guest@rabbitmq")
+from reciperadar import app
+
+
+# https://flask.palletsprojects.com/en/2.2.x/patterns/celery/
+class FlaskTask(Task):
+    def __call__(self, *args: object, **kwargs: object) -> object:
+        with app.app_context():
+            return self.run(*args, **kwargs)
+
+
+celery = Celery("reciperadar", broker="pyamqp://guest@rabbitmq", task_cls=FlaskTask)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Following upgrades to `Flask-SQLAlchemy` in the application, the `celery` worker processes began emitting errors related to the absence of a Flask application context.

This problem has been raised as #63 and that thread documents a few of the attempts to find a resolution so far.

After reading some of Flask's documentation regarding application contexts and integration with `celery`, it seems that a possible fix is to follow the recommended integration pattern for Flask + Celery.  This provides a custom subclass of `celery`'s `Task` that runs each task within a Flask application context.

### Briefly summarize the changes
1. Follow the [documentation](https://flask.palletsprojects.com/en/2.2.x/patterns/celery/) regarding integration of Flask with Celery.

### How have the changes been tested?
1. This changeset has not yet been tested within this application.

**List any issues that this change relates to**
May resolve #63.