### PR TITLE
Update/correct tests.api.test_products.test_retrieve_product_hierarchy test case to simplify the test scenario

### DIFF
--- a/reciperadar/api/products.py
+++ b/reciperadar/api/products.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Response
+from flask import Response, stream_with_context
 
 from reciperadar import app, db
 from reciperadar.models.recipes.ingredient import RecipeIngredient
@@ -9,6 +9,7 @@ from reciperadar.models.recipes.product import ProductName
 
 
 # Custom streaming method
+@stream_with_context
 def stream(items):
     for item in items:
         line = json.dumps(item, ensure_ascii=False)

--- a/reciperadar/api/products.py
+++ b/reciperadar/api/products.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Response, stream_with_context
+from flask import Response
 
 from reciperadar import app, db
 from reciperadar.models.recipes.ingredient import RecipeIngredient
@@ -9,7 +9,6 @@ from reciperadar.models.recipes.product import ProductName
 
 
 # Custom streaming method
-@stream_with_context
 def stream(items):
     for item in items:
         line = json.dumps(item, ensure_ascii=False)

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -1,35 +1,6 @@
-from flask import current_app
-import json
-from unittest.mock import patch
-
-from reciperadar.models.recipes.product import ProductName
-
-
-def mock_query():
-    """
-    Mock data generator that is lazily evaluated and includes a flask application
-    context lookup, to replicate bug https://github.com/openculinary/backend/issues/65
-    """
-    current_app._get_current_object()
-    yield from [
-        # name, nutrition, count, plural_count
-        (ProductName(id="butter"), None, 1, 1),
-        (ProductName(id="orange"), None, 5, 2),
-        (ProductName(id="apple"), None, 5, 3),
-    ]
-
-
-@patch("reciperadar.api.products.db.session.query")
-def test_retrieve_product_hierarchy(query, client):
-    (
-        query.return_value.join.return_value.join.return_value.group_by.return_value
-    ).all.return_value = mock_query()
-    expected_product_ids = {"apple", "butter", "orange"}
-
+def test_retrieve_empty_product_hierarchy(client):
     response = client.get(path="/products/hierarchy")
     products = response.data.decode("utf-8").splitlines()
-    product_ids = {json.loads(product)["id"] for product in products}
 
     assert response.status_code == 200
-    assert len(products) == 3
-    assert product_ids == expected_product_ids
+    assert len(products) == 0


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
During #66 and #67 I had developed test coverage to attempt to catch future regressions of #65.

However: I had added additional expectations to the tests related to the content of the request body, while the original failure relates purely to a streaming/context situation in Flask.

I'm often tempted to do that: to make things unnecessarily clever, or to add potentially unrelated test coverage (it often 'seems' like a good idea, to make things appear more thorough.  and sometimes, it can be useful).

The additional expectations and their fixture/mock setup tend to obscure the problem and make it less likely that regressions would be detected by the test coverage.  In other words: some of the test code changes the behaviour of the endpoint.. and that's risky if the intent here is to detect one particular code path and test that it continues to work over time.

So: be less clever, and simplify the test down to the minimum it requires.  We don't need database rows to be present (from fixtures) and we don't need to return custom data (using mock/patch methods).

### Briefly summarize the changes
1. Simplify the `tests.api.test_products.test_retrieve_product_hierarchy` test case to remove mocking of database query results.

### How have the changes been tested?
1. A temporary revert of the code fix for #65 (57e5e1afb0b39b2fdcbf602c6edec26cd3d95590) is included, and tests should fail from this commit (2a8db732974421f12ec80ed30dd7285cc50f254e).

**List any issues that this change relates to**
Fixes #65.
Relates to #66, #67.