### PR TITLE
Configure 'events' schema for all event-log-related tables

### DIFF
--- a/reciperadar/models/events/base.py
+++ b/reciperadar/models/events/base.py
@@ -9,6 +9,7 @@ from reciperadar.models.base import Storable
 class BaseEvent(Storable):
     __abstract__ = True
     __metaclass__ = ABC
+    __table_args__ = {"schema": "events"}
 
     event_id = db.Column(db.String, default=uuid4, primary_key=True)
     logged_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This places all event-logging-related database tables/models into a separate PostgreSQL database schema named `events`, allowing them to be filtered out of backups for openculinary/backups#1.

Alembic didn't seem to detect this change for the purposes of generating migration scripts, so changes were applied directly to the database:

```sql
api=> CREATE SCHEMA events;
api=> ALTER TABLE redirects SET SCHEMA events;
api=> ALTER TABLE searches SET SCHEMA events;
```

### Briefly summarize the changes
1. Set the base database schema for event-related logging tables to `events`.
2. Move the `searches` and `redirects` tables to the `events` schema.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Resolves #75.
Relates to openculinary/backups#1.