### PR TITLE
Redirects: rename intended URL landing page column from 'src' to 'dst'

### DIFF
--- a/migrations/versions/23bd350b0052_redirect_dst_instead_of_src.py
+++ b/migrations/versions/23bd350b0052_redirect_dst_instead_of_src.py
@@ -1,0 +1,34 @@
+"""redirect-dst-instead-of-src
+
+Revision ID: 23bd350b0052
+Revises: 49bad27ec620
+Create Date: 2023-08-29 11:34:40.433204
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '23bd350b0052'
+down_revision = '49bad27ec620'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        schema='events',
+        table_name='redirects',
+        column_name='src',
+        new_column_name='dst'
+    )
+
+
+def downgrade():
+    op.alter_column(
+        schema='events',
+        table_name='redirects',
+        column_name='dst',
+        new_column_name='src'
+    )

--- a/reciperadar/models/events/redirect.py
+++ b/reciperadar/models/events/redirect.py
@@ -7,4 +7,4 @@ class RedirectEvent(BaseEvent):
 
     recipe_id = db.Column(db.String)
     domain = db.Column(db.String)
-    src = db.Column(db.String)
+    dst = db.Column(db.String)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
During redirects, we send users to the recipe destination URL -- the best-known resolved URL for the recipe.  That column is known as `dst` on the `Recipe` model, compared to the `src` column that indicates the URL the recipe was retrieved from originally.  We should log the `dst` field on redirect events, and use consistent naming.

### Briefly summarize the changes
1. Renames the `events.redirects` column `src` to `dst`.

### How have the changes been tested?
1. Local development testing (migration applied, table inspected).

**List any issues that this change relates to**
Resolves #77.