### PR TITLE
Recipe directions: filter contents in database and search index

### DIFF
--- a/reciperadar/models/recipes/direction.py
+++ b/reciperadar/models/recipes/direction.py
@@ -19,6 +19,8 @@ class RecipeDirection(Storable):
 
     @staticmethod
     def _filter_markup(markup):
+        if not markup:
+            return
         include = 0
         for char in markup:
             if char == "<" and include == 0:

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -110,6 +110,13 @@ class Recipe(Storable, Indexable):
         return list(contents)
 
     @property
+    def equipment_names(self):
+        equipment_names = set()
+        for direction in self.directions:
+            equipment_names |= set(direction.equipment_names or [])
+        return list(equipment_names)
+
+    @property
     def aggregate_ingredient_nutrition(self):
         all_ingredients_mass = sum([i.mass or 0 for i in self.ingredients])
         ingredients_with_nutrition_mass = sum(
@@ -187,9 +194,10 @@ class Recipe(Storable, Indexable):
 
     def to_doc(self):
         data = super().to_doc()
-        data["directions"] = [direction.to_doc() for direction in self.directions]
+        # data["directions"] = [direction.to_doc() for direction in self.directions]
         data["ingredients"] = [ingredient.to_doc() for ingredient in self.ingredients]
         data["contents"] = self.contents
+        data["equipment_names"] = self.equipment_names
         data["product_count"] = len(self.product_names)
         data["hidden"] = self.hidden
         data["nutrition"] = (

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -36,15 +36,6 @@ settings = {
 }
 mapping = {
     'properties': {
-        'directions': {
-            'properties': {
-                'equipment': {
-                    'properties': {
-                        'name': {'type': 'keyword'}
-                    }
-                }
-            }
-        },
         'ingredients': {
             'type': 'nested',
             'properties': {

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -70,6 +70,7 @@ mapping = {
             }
         },
         'contents': {'type': 'keyword'},
+        'equipment_names': {'type': 'keyword'},
         'domain': {'type': 'keyword'}
     }
 }

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -13,12 +13,27 @@ def test_recipe_from_doc(db_session, raw_recipe_hit):
 
     assert recipe.directions[0].equipment[0].name == "skewer"
     assert recipe.directions[0].equipment[1].name == "oven"
+    assert recipe.directions[0].markup == (
+        "<mark class='verb action'>place</mark>"
+        "<mark class='equipment utensil'>skewer</mark>"
+        "<mark class='equipment appliance'>oven</mark>"
+    )
 
     assert recipe.ingredients[0].product_name.singular == "one"
     expected_contents = ["one", "ancestor-of-one"]
     actual_contents = recipe.ingredients[0].product_name.contents
 
     assert all([content in actual_contents for content in expected_contents])
+
+    expected_equipment_names = ["oven", "skewer"]
+    actual_equipment_names = recipe.equipment_names
+
+    assert all(
+        [
+            equipment_name in actual_equipment_names
+            for equipment_name in expected_equipment_names
+        ]
+    )
 
     assert recipe.ingredients[0].nutrition.carbohydrates == 0
     assert recipe.ingredients[0].nutrition.fibre == 0.65


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
We haven't made recipe directions available via the API nor web interface since 2021-03-01 (see openculinary/api#101) and we can save some space both on-disk and in memory by filtering out directions.

We also don't really need to store the entire text of directions, so at the same time, filter the contents of of the direction `description` and `markup` fields.  We do want to retain some entities recognized during recipe crawling, especially items of cooking equipment since those are user-queryable.

### Briefly summarize the changes
1. Drop the `directions` field from recipes in the search index.
1. Filter the contents of the `description` and `markup` fields for recipe directions in the database.

### How have the changes been tested?
1. Unit test coverage is added.

**List any issues that this change relates to**
Relates to openculinary/api#101.