### PR TITLE
Refactor: relocate find_earliest_crawl, find_latest_crawl methods

### DIFF
--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -83,16 +83,11 @@ class CrawlURL(BaseURL):
             self.resolves_to = response.json()["url"]["resolves_to"]
         return response
 
-
-class RecipeURL(BaseURL):
-    __tablename__ = "recipe_urls"
-
-    recipe_scrapers_version = db.Column(db.String)
-
-    def find_earliest_crawl(self):
+    @staticmethod
+    def find_earliest_crawl(url):
         earliest_crawl = (
             db.session.query(CrawlURL)
-            .filter_by(resolves_to=self.url)
+            .filter_by(resolves_to=url)
             .cte(recursive=True)
         )
 
@@ -107,10 +102,11 @@ class RecipeURL(BaseURL):
             .first()
         )
 
-    def find_latest_crawl(self):
+    @staticmethod
+    def find_latest_crawl(url):
         latest_crawl = (
             db.session.query(CrawlURL)
-            .filter_by(resolves_to=self.url)
+            .filter_by(resolves_to=url)
             .cte(recursive=True)
         )
 
@@ -124,6 +120,12 @@ class RecipeURL(BaseURL):
             .order_by(latest_crawl.c.latest_crawled_at.desc())
             .first()
         )
+
+
+class RecipeURL(BaseURL):
+    __tablename__ = "recipe_urls"
+
+    recipe_scrapers_version = db.Column(db.String)
 
     def _make_request(self):
         response = httpx.post(

--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -86,9 +86,7 @@ class CrawlURL(BaseURL):
     @staticmethod
     def find_earliest_crawl(url):
         earliest_crawl = (
-            db.session.query(CrawlURL)
-            .filter_by(resolves_to=url)
-            .cte(recursive=True)
+            db.session.query(CrawlURL).filter_by(resolves_to=url).cte(recursive=True)
         )
 
         previous_step = db.aliased(earliest_crawl)
@@ -105,9 +103,7 @@ class CrawlURL(BaseURL):
     @staticmethod
     def find_latest_crawl(url):
         latest_crawl = (
-            db.session.query(CrawlURL)
-            .filter_by(resolves_to=url)
-            .cte(recursive=True)
+            db.session.query(CrawlURL).filter_by(resolves_to=url).cte(recursive=True)
         )
 
         previous_step = db.aliased(latest_crawl)

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -132,17 +132,13 @@ def crawl_recipe(url):
     """
 
     # Find any more-recent crawls of this URL, allowing detection of duplicates
-    latest_crawl = recipe_url.find_latest_crawl()
+    latest_crawl = CrawlURL.find_latest_crawl(recipe_url.url)
     if not latest_crawl:
         print(f"Failed to find latest crawl for url={url}")
         return
 
-    latest_recipe_url = db.session.get(RecipeURL, latest_crawl.url) or RecipeURL(
-        url=latest_crawl.url
-    )
-
     # Find the first-known crawl for the latest URL, and consider it the origin
-    earliest_crawl = latest_recipe_url.find_earliest_crawl()
+    earliest_crawl = CrawlURL.find_earliest_crawl(latest_crawl.url)
     if not earliest_crawl:
         print(f"Failed to find earliest crawl for url={url}")
         return

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -61,9 +61,9 @@ def test_crawl_url_timeline(db_session):
     for step in path:
         db_session.add(step)
 
-    recipe = RecipeURL(url="//example.org/C")
-    earliest_crawl = recipe.find_earliest_crawl()
-    latest_crawl = recipe.find_latest_crawl()
+    url = "//example.org/C"
+    earliest_crawl = CrawlURL.find_earliest_crawl(url)
+    latest_crawl = CrawlURL.find_latest_crawl(url)
 
     assert earliest_crawl.url == "//example.org/A"
     assert latest_crawl.url == "//example.org/D"
@@ -91,8 +91,7 @@ def test_crawl_url_relocation_stability(utcnow_mock, db_session, respx_mock):
         url.crawl()
         db_session.add(url)
 
-        recipe_url = RecipeURL(url=to_url)
-        origin = recipe_url.find_earliest_crawl()
+        origin = CrawlURL.find_earliest_crawl(to_url)
         origin_urls.add(origin.url)
 
     assert len(origin_urls) == 1


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
A preparatory refactor to make the `find_earliest_crawl` and `find_latest_crawl` instance methods from `RecipeURL` easier to use as static utility methods on `CrawlURL`.

### Briefly summarize the changes
1. Move `find_earliest_crawl` and `find_latest_crawl` from `RecipeURL` to `CrawlURL` and adjust  their method signatures (static, from zero args to one arg).

### How have the changes been tested?
1. Unit testing only.

**List any issues that this change relates to**
Relates to #82.