### PR TITLE
Data management: assign 'pork' as the parent product of 'bacon'

### DIFF
--- a/scripts/data/products.csv
+++ b/scripts/data/products.csv
@@ -14,7 +14,7 @@ parent_id,id,singular,plural,category,is_kitchen_staple,is_dairy_free,is_gluten_
 ,arugula,arugula,arugulas,,f,t,t,t,t
 ,asafoetida,asafoetida,asafoetidas,,f,t,t,t,t
 ketchup,catsup,catsup,catsups,,f,t,t,t,t
-,bacon,bacon,bacons,meat_and_deli,f,t,t,f,f
+pork,bacon,bacon,bacons,meat_and_deli,f,t,t,f,f
 ,bamboo_shoot,bamboo shoot,bamboo shoots,,f,t,t,t,t
 ,banana,banana,bananas,fruit_and_veg,f,t,t,t,t
 ,banana_chip,banana chip,banana chips,fruit_and_veg,f,t,t,t,t


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Bacon is generally considered to be a pork product; and as reported in #97, we should exclude recipes that contain bacon from searches that request pork to be an excluded ingredient.

### Briefly summarize the changes
1. Add `pork` as the parent category for `bacon`.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Partially addresses #97.